### PR TITLE
feat!: add registries into account configuration

### DIFF
--- a/cmdb/account/README.md
+++ b/cmdb/account/README.md
@@ -1,5 +1,4 @@
 # Account
 
 This template is for the creation of a Hamlet account. The account template can be reused to create multiple accounts within a Tenant
-
 This template should be run from a tenant directory

--- a/cmdb/account/cookiecutter.json
+++ b/cmdb/account/cookiecutter.json
@@ -2,6 +2,6 @@
     "account_id" : "",
     "account_name" : "{{cookiecutter.account_id}}",
     "account_seed" : "{% set seq = ['0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z'] %}{% for n in range(10) %}{{ seq | random }}{% endfor %}",
-    "account_type" : [ "aws" ],
-    "aws_account_id" : "{{ '' if cookiecutter.account_type == 'aws' else 'n/a' }}"
+    "provider_type" : [ "aws", "azure" ],
+    "provider_id" : ""
 }

--- a/cmdb/account/{{cookiecutter.account_name}}/config/account.json
+++ b/cmdb/account/{{cookiecutter.account_name}}/config/account.json
@@ -3,7 +3,7 @@
         "Id" : "{{cookiecutter.account_id}}",
         "Name" : "{{cookiecutter.account_name}}",
         "Seed" : "{{cookiecutter.account_seed}}",
-        "Provider" : "{{cookiecutter.account_type}}",
-        "ProviderId" : "{{cookiecutter.aws_account_id}}"
+        "Provider" : "{{cookiecutter.provider_type}}",
+        "ProviderId" : "{{cookiecutter.provider_id}}"
     }
 }

--- a/cmdb/account/{{cookiecutter.account_name}}/config/account.json
+++ b/cmdb/account/{{cookiecutter.account_name}}/config/account.json
@@ -2,10 +2,8 @@
     "Account" : {
         "Id" : "{{cookiecutter.account_id}}",
         "Name" : "{{cookiecutter.account_name}}",
-        "Seed" : "{{cookiecutter.account_seed}}"
-        {% if cookiecutter.account_type == "aws"  %}
-        ,
-        "AWSId" : "{{cookiecutter.aws_account_id}}"
-        {% endif %}
+        "Seed" : "{{cookiecutter.account_seed}}",
+        "Provider" : "{{cookiecutter.account_type}}",
+        "ProviderId" : "{{cookiecutter.aws_account_id}}"
     }
 }

--- a/cmdb/account/{{cookiecutter.account_name}}/config/settings/shared/settings.json
+++ b/cmdb/account/{{cookiecutter.account_name}}/config/settings/shared/settings.json
@@ -1,5 +1,6 @@
 {
     "Registries" : {
+        {%- if cookeicutter.provider_type == "aws" -%}
         "docker" : {
             "EndPoint" : "{{cookiecutter.aws_account_id}}.dkr.ecr.ap-southeast-2.amazonaws.com"
         },
@@ -35,5 +36,6 @@
             "EndPoint" : "rds",
             "Prefix" : "registry"
         }
+        {% endif %}
     }
 }

--- a/cmdb/account/{{cookiecutter.account_name}}/config/settings/shared/settings.json
+++ b/cmdb/account/{{cookiecutter.account_name}}/config/settings/shared/settings.json
@@ -1,5 +1,39 @@
 {
     "Registries" : {
-
+        "docker" : {
+            "EndPoint" : "{{cookiecutter.aws_account_id}}.dkr.ecr.ap-southeast-2.amazonaws.com"
+        },
+        "lambda" : {
+            "EndPoint" : "account-registry-{{cookiecutter.account_seed}}",
+            "Prefix" : "lambda/"
+        },
+        "openapi" : {
+            "EndPoint" : "account-registry-{{cookiecutter.account_seed}}",
+            "Prefix" : "openapi/"
+        },
+        "spa" : {
+            "EndPoint" : "account-registry-{{cookiecutter.account_seed}}",
+            "Prefix" : "spa/"
+        },
+        "scripts" : {
+            "EndPoint" : "account-registry-{{cookiecutter.account_seed}}",
+            "Prefix" : "scripts/"
+        },
+        "contentnode" : {
+            "EndPoint" : "account-registry-{{cookiecutter.account_seed}}",
+            "Prefix" : "contentnode/"
+        },
+        "dataset" : {
+            "EndPoint" : "account-registry-{{cookiecutter.account_seed}}",
+            "Prefix" : "dataset/"
+        },
+        "pipeline" : {
+            "EndPoint" : "account-registry-{{cookiecutter.account_seed}}",
+            "Prefix" : "pipeline/"
+        },
+        "rdssnapshot" : {
+            "EndPoint" : "rds",
+            "Prefix" : "registry"
+        }
     }
 }


### PR DESCRIPTION
## Description

- Configures all of the current registries as part of the standard account configuration.
- Moves to using ProviderId and Provider instead of the AWSId configuration

This also updates the input parameters for the provider Id migration and as a result is a breaking change

## Motivation and Context
 This reduces the configuration required  when working with accounts and provides a cleaner bootstrapping process 

## How Has This Been Tested?
Tested locally 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
