### PR TITLE
fix: always include domain Id for Product

### DIFF
--- a/products/base/{{cookiecutter.product_name}}/config/product.json
+++ b/products/base/{{cookiecutter.product_name}}/config/product.json
@@ -1,8 +1,8 @@
 {
     "Product" : {
         "Id" : "{{cookiecutter.product_id}}",
-        "Name" : "{{cookiecutter.product_name}}"{% if cookiecutter.domain_zone != "" %},
-        "Domain" : "{{cookiecutter.product_id}}"{% endif %}
+        "Name" : "{{cookiecutter.product_name}}",
+        "Domain" : "{{cookiecutter.product_id}}"
     }{% if cookiecutter.domain_zone != "" %},
     "Domains" : {
         "{{cookiecutter.product_id}}" : {


### PR DESCRIPTION
## Description

Don't ignore setting the Domain Id in the product section even when the domain zone hasn't been set

## Motivation and Context

If this is not included setContext raises an exception that the Domain property could not be found

## How Has This Been Tested?

Tested locally 

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions

- [x] None

## Checklist:

- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
