### PR TITLE
fix: repo url in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,31 +1,31 @@
-# [0.0.0](https://github.com/hamlet-io/engine-plugin-aws/compare/v8.0.1...v0.0.0) (2021-03-30)
+# [0.0.0](https://github.com/hamlet-io/executor-cookiecutter/compare/v8.0.1...v0.0.0) (2021-04-02)
 
 
 
-## [8.0.1](https://github.com/hamlet-io/engine-plugin-aws/compare/v8.0.0...v8.0.1) (2021-03-11)
+## [8.0.1](https://github.com/hamlet-io/executor-cookiecutter/compare/v8.0.0...v8.0.1) (2021-03-11)
 
 
 ### Bug Fixes
 
-* typo in account settings ([9ab12af](https://github.com/hamlet-io/engine-plugin-aws/commit/9ab12af7ea0adf7830dda7a5be1e45a6b2f642cd))
-* **ci:** update job trigger for docker ([b95c8dd](https://github.com/hamlet-io/engine-plugin-aws/commit/b95c8ddc37d45fb14a8c0d152144d64fab9a1d45))
+* **ci:** update job trigger for docker ([b95c8dd](https://github.com/hamlet-io/executor-cookiecutter/commit/b95c8ddc37d45fb14a8c0d152144d64fab9a1d45))
+* typo in account settings ([9ab12af](https://github.com/hamlet-io/executor-cookiecutter/commit/9ab12af7ea0adf7830dda7a5be1e45a6b2f642cd))
 
 
 
-# [8.0.0](https://github.com/hamlet-io/engine-plugin-aws/compare/v7.0.0...v8.0.0) (2021-01-11)
+# [8.0.0](https://github.com/hamlet-io/executor-cookiecutter/compare/v7.0.0...v8.0.0) (2021-01-11)
 
 
 ### Features
 
-* changelog generation ([aa00c90](https://github.com/hamlet-io/engine-plugin-aws/commit/aa00c90ad455022920a88fc5823a5fd69b82acd5))
+* changelog generation ([aa00c90](https://github.com/hamlet-io/executor-cookiecutter/commit/aa00c90ad455022920a88fc5823a5fd69b82acd5))
 
 
 
-# [7.0.0](https://github.com/hamlet-io/engine-plugin-aws/compare/v6.0.0...v7.0.0) (2020-03-20)
+# [7.0.0](https://github.com/hamlet-io/executor-cookiecutter/compare/v6.0.0...v7.0.0) (2020-03-20)
 
 
 
-# [6.0.0](https://github.com/hamlet-io/engine-plugin-aws/compare/v5.5.8...v6.0.0) (2019-06-06)
+# [6.0.0](https://github.com/hamlet-io/executor-cookiecutter/compare/v5.5.8...v6.0.0) (2019-06-06)
 
 
 

--- a/package.json
+++ b/package.json
@@ -17,12 +17,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hamlet-io/engine-plugin-aws.git"
+    "url": "git+https://github.com/hamlet-io/executor-cookiecutter.git"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/hamlet-io/engine-plugin-aws/issues"
+    "url": "https://github.com/hamlet-io/executor-cookiecutter/issues"
   },
-  "homepage": "https://github.com/hamlet-io/engine-plugin-aws#readme"
+  "homepage": "https://github.com/hamlet-io/executor-cookiecutter#readme"
 }


### PR DESCRIPTION
## Description

fix the url referenced in changelogs to align with each repo

## Motivation and Context

Makes the changelog understandable

## How Has This Been Tested?

Tested locally 

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions

- [x] None

## Checklist:

- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
